### PR TITLE
Changed modal style of the demo so that it uses the side cart

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <nuxt />
-    <div hidden id="snipcart" data-api-key="MzMxN2Y0ODMtOWNhMy00YzUzLWFiNTYtZjMwZTRkZDcxYzM4"></div>
+    <div hidden id="snipcart" data-api-key="MzMxN2Y0ODMtOWNhMy00YzUzLWFiNTYtZjMwZTRkZDcxYzM4" data-config-modal-style="side"></div>
   </div>
 </template>
 


### PR DESCRIPTION
Demo will use use `side` modal style configured via `data-config-modal-style` that became available in v3.0.26.